### PR TITLE
4.1.2

### DIFF
--- a/.frontmatter/database/taxonomyDb.json
+++ b/.frontmatter/database/taxonomyDb.json
@@ -1,1 +1,1 @@
-{"taxonomy":{"categories":[],"tags":["tag1","tag2","tag3","tag4","tag5","unique"]}}
+{"taxonomy":{"categories":[],"tags":["_home","_search","tag1","tag2","tag3","tag4","tag5","unik","unique"]}}

--- a/.frontmatter/frontmatter.json
+++ b/.frontmatter/frontmatter.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://frontmatter.codes/frontmatter.schema.json",
+  "frontMatter.contentHealth.enabled": true,
+  "frontMatter.contentHealth.checkExternalLinks": true,
+  "frontMatter.contentHealth.freshnessThreshold": 180,
+  "frontMatter.contentHealth.minReadability": 40,
   "frontMatter.framework.id": "11ty",
   "frontMatter.preview.host": "http://localhost:8080",
   "frontMatter.dashboard.openOnStart": true,

--- a/content/_data/types.json
+++ b/content/_data/types.json
@@ -1,7 +1,7 @@
 {
     "posts": {
         "label": "Posts",
-        "prefix": "writing",
+        "prefix": "blog",
         "protected": true,
         "searchable": true,
         "feed": true,

--- a/content/en/pages/404.md
+++ b/content/en/pages/404.md
@@ -9,4 +9,4 @@ eleventyExcludeFromCollections: true
 
 {% include "search.njk" %}
 
-Sorry, that page doesn't exist! [Try visiting the home page!](/) or search below. Please let me know if you encounter more errors: <a :href="'mailto:'.concat(atob('{{ settings.author.email | base64 }}'))" x-data x-text="atob('{{ settings.author.email | base64 }}')" class="email"></a>.
+Sorry, that page doesn't exist! [Try visiting the home page!](/) or search above. Please let me know if you encounter more errors: <a :href="'mailto:'.concat(atob('{{ settings.author.email | base64 }}'))" x-data x-text="atob('{{ settings.author.email | base64 }}')" class="email"></a>.

--- a/content/en/pages/404.md
+++ b/content/en/pages/404.md
@@ -7,6 +7,6 @@ permalink: "{{ ('/' + lang + '/404.html') | default_locale_url }}"
 eleventyExcludeFromCollections: true
 ---
 
-Sorry, that page doesn't exist! [Try visiting the home page!](/) or search below. Please let me know if you encounter more errors: <a :href="'mailto:'.concat(atob('{{ settings.author.email | base64 }}'))" x-data x-text="atob('{{ settings.author.email | base64 }}')" class="email"></a>.
-
 {% include "search.njk" %}
+
+Sorry, that page doesn't exist! [Try visiting the home page!](/) or search below. Please let me know if you encounter more errors: <a :href="'mailto:'.concat(atob('{{ settings.author.email | base64 }}'))" x-data x-text="atob('{{ settings.author.email | base64 }}')" class="email"></a>.

--- a/content/en/posts/translations.md
+++ b/content/en/posts/translations.md
@@ -101,7 +101,7 @@ Translations can include placeholders that are replaced with values passed as th
 
 This renders as: `Hello, Alice!`
 
-### Pluralization
+### Pluralisation
 
 For strings that change based on a count, use the `count` object with `one` and `other` keys in your translation file. The filter uses the `Intl.PluralRules` API to select the correct form based on the language's pluralization rules.
 

--- a/content/sv/pages/404.md
+++ b/content/sv/pages/404.md
@@ -9,4 +9,4 @@ eleventyExcludeFromCollections: true
 
 {% include "search.njk" %}
 
-Forlåt, den sidan finns inte! [Besök hemsidan!](/) eller sök nedan. Maila mig om du stöter på fler fel: <a :href="'mailto:'.concat(atob('{{ settings.author.email | base64 }}'))" x-data x-text="atob('{{ settings.author.email | base64 }}')" class="email"></a>.
+Forlåt, den sidan finns inte! [Besök hemsidan!](/) eller sök ovan. Maila mig om du stöter på fler fel: <a :href="'mailto:'.concat(atob('{{ settings.author.email | base64 }}'))" x-data x-text="atob('{{ settings.author.email | base64 }}')" class="email"></a>.

--- a/content/sv/pages/404.md
+++ b/content/sv/pages/404.md
@@ -7,6 +7,6 @@ permalink: "{{ ('/' + lang + '/404.html') | default_locale_url }}"
 eleventyExcludeFromCollections: true
 ---
 
-Forlåt, den sidan finns inte! [Besök hemsidan!](/) eller sök nedan. Maila mig om du stöter på fler fel: <a :href="'mailto:'.concat(atob('{{ settings.author.email | base64 }}'))" x-data x-text="atob('{{ settings.author.email | base64 }}')" class="email"></a>.
-
 {% include "search.njk" %}
+
+Forlåt, den sidan finns inte! [Besök hemsidan!](/) eller sök nedan. Maila mig om du stöter på fler fel: <a :href="'mailto:'.concat(atob('{{ settings.author.email | base64 }}'))" x-data x-text="atob('{{ settings.author.email | base64 }}')" class="email"></a>.

--- a/elva/filters/readingtime.js
+++ b/elva/filters/readingtime.js
@@ -2,7 +2,7 @@
 // based on https://www.bobmonsour.com/posts/calculating-reading-time/
 import { translate } from './translate.js';
 
-export function readingtime(text) {
+export async function readingtime(text) {
     let content = new String(text);
     const speed = 240; // reading speed in words per minute
   
@@ -22,6 +22,6 @@ export function readingtime(text) {
     if (readingTime === 0) {
     	return this.ctx.translations[this.page.lang || this.ctx.lang].readingTime.underMinute;
     } else {
-    	return translate.call(this, 'readingTime.count', this.page.lang || this.ctx.lang, { minutes: readingTime });
+    	return await translate.call(this, 'readingTime.count', this.page.lang || this.ctx.lang, { minutes: readingTime });
     }
-};
+}

--- a/elva/filters/translate.js
+++ b/elva/filters/translate.js
@@ -11,13 +11,13 @@ export function translate(lookup, lang, data = {}) {
     const value = getProperty(this.ctx.translations[lang], lookup);
     if (!value) return lookup;
 
-    // find count for pluralization: explicit count key, or first numeric value in data
+    // find count for pluralisation: explicit count key, or first numeric value in data
     let count = data.count;
     if (count === undefined) {
         count = Object.values(data).find(v => typeof v === 'number');
     }
 
-    // handle pluralization: if value is an object with one/other keys and count is found
+    // handle pluralisation: if value is an object with one/other keys and count is found
     if (typeof value === 'object' && !Array.isArray(value) && count !== undefined) {
         const pluralRules = new Intl.PluralRules(lang);
         const pluralForm = pluralRules.select(count);

--- a/elva/filters/translate.js
+++ b/elva/filters/translate.js
@@ -5,7 +5,7 @@ import nunjucks from '@11ty/nunjucks';
 import { getProperty } from 'dot-prop';
 nunjucks.configure({ autoescape: true });
 
-export function translate(lookup, lang, data = {}) {
+export async function translate(lookup, lang, data = {}) {
     if (!lang) lang = this.page.lang || this.ctx.lang;
     // traverse the translations object using the dot-separated lookup path
     const value = getProperty(this.ctx.translations[lang], lookup);
@@ -23,13 +23,13 @@ export function translate(lookup, lang, data = {}) {
         const pluralForm = pluralRules.select(count);
         const pluralValue = value[pluralForm];
         if (typeof pluralValue === 'string') {
-            return nunjucks.renderString(pluralValue, data);
+            return await nunjucks.renderString(pluralValue, data);
         }
     }
 
     // handle variable substitution
     if (typeof value === 'string') {
-        return nunjucks.renderString(value, data);
+        return await nunjucks.renderString(value, data);
     }
 
     return value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy": "4.0.0-alpha.7",
+        "@11ty/eleventy": "4.0.0-alpha.8",
         "@11ty/eleventy-fetch": "^5.1.2",
         "@11ty/eleventy-img": "^6.0.4",
         "@11ty/eleventy-navigation": "^1.0.5",
@@ -75,52 +75,53 @@
       }
     },
     "node_modules/@11ty/eleventy": {
-      "version": "4.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-4.0.0-alpha.7.tgz",
-      "integrity": "sha512-DbWXc7mOa/9ddnUeYe+P+sQkOxnEtqE/E3C7Wa1ixP43kCgQVjN3yE/4xDNdRkG8AzlcJypeR1jwVjoYPMubSQ==",
+      "version": "4.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-4.0.0-alpha.8.tgz",
+      "integrity": "sha512-H7RImi+3MmmZXbqJ1kMBNvtpRKAWzZYFrhqXfGqwzdw7TXxPNT0MPcjGfX1edLXY0SZ2hG98Ue6TDzZD1W3NPA==",
       "license": "MIT",
       "workspaces": [
-        "packages/client"
+        "packages/browser",
+        "packages/build-awesome"
       ],
       "dependencies": {
         "@11ty/dependency-tree": "^4.0.2",
         "@11ty/dependency-tree-esm": "^2.0.4",
         "@11ty/dependency-tree-typescript": "^1.0.0",
-        "@11ty/eleventy-dev-server": "^3.0.0-alpha.6",
+        "@11ty/eleventy-dev-server": "^3.0.0-alpha.10",
         "@11ty/eleventy-plugin-bundle": "^3.0.7",
         "@11ty/eleventy-utils": "^2.0.7",
-        "@11ty/gray-matter": "^2.0.1",
+        "@11ty/gray-matter": "^2.1.0",
         "@11ty/lodash-custom": "^4.17.21",
         "@11ty/node-version-check": "^1.0.1",
         "@11ty/nunjucks": "^4.0.0-alpha.1",
         "@11ty/parse-date-strings": "^2.0.6",
-        "@11ty/posthtml-urls": "^1.0.2",
+        "@11ty/posthtml-urls": "^1.0.3",
         "@11ty/recursive-copy": "^5.0.2",
         "@sindresorhus/slugify": "^3.0.0",
         "bcp-47-normalize": "^2.3.0",
         "chokidar": "^5.0.0",
-        "debug": "^4.4.3",
         "dependency-graph": "^1.0.0",
         "entities": "^8.0.0",
         "import-module-string": "^2.0.3",
         "iso-639-1": "^3.1.5",
         "kleur": "^4.1.5",
-        "liquidjs": "^10.25.0",
-        "markdown-it": "^14.1.1",
+        "liquidjs": "^10.27.0",
+        "markdown-it": "^14.2.0",
         "minimist": "^1.2.8",
         "moo": "0.5.2",
         "node-retrieve-globals": "^6.0.1",
-        "picomatch": "^4.0.3",
+        "obug": "^2.1.3",
+        "picomatch": "^4.0.4",
         "posthtml": "^0.16.7",
         "posthtml-match-helper": "^2.0.3",
-        "semver": "^7.7.4",
-        "tinyglobby": "^0.2.15"
+        "semver": "^7.8.4",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "eleventy": "cmd.cjs"
       },
       "engines": {
-        "node": ">=20.19"
+        "node": ">=22.15"
       },
       "funding": {
         "type": "opencollective",
@@ -128,9 +129,9 @@
       }
     },
     "node_modules/@11ty/eleventy-dev-server": {
-      "version": "3.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-dev-server/-/eleventy-dev-server-3.0.0-alpha.8.tgz",
-      "integrity": "sha512-DcMfE8Ca/kAlwFjkpT37PQFmdzzVQnt6eBt3yZzgIadBf7Dt5tAcW3t5uSr2TPYyAEEXh4Aq/dZNPWrEb8JWVQ==",
+      "version": "3.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-dev-server/-/eleventy-dev-server-3.0.0-alpha.10.tgz",
+      "integrity": "sha512-/3bR71s1Wgavp6wmTWPSEmVbNIawnaZiushHIPMuq9vVUKwJtegmY9C1TTPD2Z/Z1IHzuft/QNlZxEnKzXJttw==",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-utils": "^2.0.7",
@@ -142,15 +143,14 @@
         "minimist": "^1.2.8",
         "morphdom": "^2.7.8",
         "send": "^1.2.1",
-        "ssri": "^13.0.1",
         "urlpattern-polyfill": "^10.1.0",
-        "ws": "^8.20.0"
+        "ws": "^8.21.0"
       },
       "bin": {
         "eleventy-dev-server": "cmd.cjs"
       },
       "engines": {
-        "node": ">=20.19"
+        "node": ">=22.15"
       },
       "funding": {
         "type": "opencollective",
@@ -286,12 +286,12 @@
       }
     },
     "node_modules/@11ty/gray-matter": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@11ty/gray-matter/-/gray-matter-2.0.2.tgz",
-      "integrity": "sha512-+sbmr+BPzzi0z4lFvruKiGQ3D/d5zBssavhH9SzXmWkf7rStnB4gfeEMgz6k1Ac8bpN5NAFCH5GyR3xHk1BGPA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@11ty/gray-matter/-/gray-matter-2.1.0.tgz",
+      "integrity": "sha512-fNdBOb3MgDz/1UCIoeY4wDuGbp+/3s5y6UrsyfMabECbh/CVycj7Er33JXqSxRwxrRKXcGE1Jipuq/1mODInsQ==",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "section-matter": "^1.0.0"
       },
       "engines": {
@@ -3062,15 +3062,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/moo": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
@@ -3137,6 +3128,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -3561,9 +3565,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3681,18 +3685,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/ssri": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/statuses": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy": "4.0.0-alpha.8",
+        "@11ty/eleventy": "4.0.0-alpha.7",
         "@11ty/eleventy-fetch": "^5.1.2",
         "@11ty/eleventy-img": "^6.0.4",
         "@11ty/eleventy-navigation": "^1.0.5",
@@ -75,53 +75,52 @@
       }
     },
     "node_modules/@11ty/eleventy": {
-      "version": "4.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-4.0.0-alpha.8.tgz",
-      "integrity": "sha512-H7RImi+3MmmZXbqJ1kMBNvtpRKAWzZYFrhqXfGqwzdw7TXxPNT0MPcjGfX1edLXY0SZ2hG98Ue6TDzZD1W3NPA==",
+      "version": "4.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-4.0.0-alpha.7.tgz",
+      "integrity": "sha512-DbWXc7mOa/9ddnUeYe+P+sQkOxnEtqE/E3C7Wa1ixP43kCgQVjN3yE/4xDNdRkG8AzlcJypeR1jwVjoYPMubSQ==",
       "license": "MIT",
       "workspaces": [
-        "packages/browser",
-        "packages/build-awesome"
+        "packages/client"
       ],
       "dependencies": {
         "@11ty/dependency-tree": "^4.0.2",
         "@11ty/dependency-tree-esm": "^2.0.4",
         "@11ty/dependency-tree-typescript": "^1.0.0",
-        "@11ty/eleventy-dev-server": "^3.0.0-alpha.10",
+        "@11ty/eleventy-dev-server": "^3.0.0-alpha.6",
         "@11ty/eleventy-plugin-bundle": "^3.0.7",
         "@11ty/eleventy-utils": "^2.0.7",
-        "@11ty/gray-matter": "^2.1.0",
+        "@11ty/gray-matter": "^2.0.1",
         "@11ty/lodash-custom": "^4.17.21",
         "@11ty/node-version-check": "^1.0.1",
         "@11ty/nunjucks": "^4.0.0-alpha.1",
         "@11ty/parse-date-strings": "^2.0.6",
-        "@11ty/posthtml-urls": "^1.0.3",
+        "@11ty/posthtml-urls": "^1.0.2",
         "@11ty/recursive-copy": "^5.0.2",
         "@sindresorhus/slugify": "^3.0.0",
         "bcp-47-normalize": "^2.3.0",
         "chokidar": "^5.0.0",
+        "debug": "^4.4.3",
         "dependency-graph": "^1.0.0",
         "entities": "^8.0.0",
         "import-module-string": "^2.0.3",
         "iso-639-1": "^3.1.5",
         "kleur": "^4.1.5",
-        "liquidjs": "^10.27.0",
-        "markdown-it": "^14.2.0",
+        "liquidjs": "^10.25.0",
+        "markdown-it": "^14.1.1",
         "minimist": "^1.2.8",
         "moo": "0.5.2",
         "node-retrieve-globals": "^6.0.1",
-        "obug": "^2.1.3",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.3",
         "posthtml": "^0.16.7",
         "posthtml-match-helper": "^2.0.3",
-        "semver": "^7.8.4",
-        "tinyglobby": "^0.2.17"
+        "semver": "^7.7.4",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "eleventy": "cmd.cjs"
       },
       "engines": {
-        "node": ">=22.15"
+        "node": ">=20.19"
       },
       "funding": {
         "type": "opencollective",
@@ -3128,19 +3127,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy": "4.0.0-alpha.7",
+        "@11ty/eleventy": "4.0.0-alpha.10",
         "@11ty/eleventy-fetch": "^5.1.3",
         "@11ty/eleventy-img": "^6.0.4",
         "@11ty/eleventy-navigation": "^1.0.5",
@@ -75,52 +75,53 @@
       }
     },
     "node_modules/@11ty/eleventy": {
-      "version": "4.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-4.0.0-alpha.7.tgz",
-      "integrity": "sha512-DbWXc7mOa/9ddnUeYe+P+sQkOxnEtqE/E3C7Wa1ixP43kCgQVjN3yE/4xDNdRkG8AzlcJypeR1jwVjoYPMubSQ==",
+      "version": "4.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-4.0.0-alpha.10.tgz",
+      "integrity": "sha512-yAJ3L9l+5GtFZ9c4Zu9dJEUGbxSKGwK7mQDeaZNlNewny9APUHdW8xaPIip5140xvlL7QRFRct1GdPNg93kVGg==",
       "license": "MIT",
       "workspaces": [
-        "packages/client"
+        "packages/browser",
+        "packages/build-awesome"
       ],
       "dependencies": {
         "@11ty/dependency-tree": "^4.0.2",
         "@11ty/dependency-tree-esm": "^2.0.4",
         "@11ty/dependency-tree-typescript": "^1.0.0",
-        "@11ty/eleventy-dev-server": "^3.0.0-alpha.6",
-        "@11ty/eleventy-plugin-bundle": "^3.0.7",
+        "@11ty/eleventy-dev-server": "^3.0.0-alpha.10",
+        "@11ty/eleventy-plugin-bundle": "^4.0.2",
         "@11ty/eleventy-utils": "^2.0.7",
-        "@11ty/gray-matter": "^2.0.1",
+        "@11ty/gray-matter": "^2.1.0",
         "@11ty/lodash-custom": "^4.17.21",
         "@11ty/node-version-check": "^1.0.1",
-        "@11ty/nunjucks": "^4.0.0-alpha.1",
+        "@11ty/nunjucks": "^4.0.0-alpha.3",
         "@11ty/parse-date-strings": "^2.0.6",
-        "@11ty/posthtml-urls": "^1.0.2",
+        "@11ty/posthtml-urls": "^1.0.3",
         "@11ty/recursive-copy": "^5.0.2",
         "@sindresorhus/slugify": "^3.0.0",
         "bcp-47-normalize": "^2.3.0",
         "chokidar": "^5.0.0",
-        "debug": "^4.4.3",
         "dependency-graph": "^1.0.0",
         "entities": "^8.0.0",
         "import-module-string": "^2.0.3",
         "iso-639-1": "^3.1.5",
         "kleur": "^4.1.5",
-        "liquidjs": "^10.25.0",
-        "markdown-it": "^14.1.1",
+        "liquidjs": "^10.27.1",
+        "markdown-it": "^14.2.0",
         "minimist": "^1.2.8",
         "moo": "0.5.2",
         "node-retrieve-globals": "^6.0.1",
-        "picomatch": "^4.0.3",
+        "obug": "^2.1.3",
+        "picomatch": "^4.0.4",
         "posthtml": "^0.16.7",
         "posthtml-match-helper": "^2.0.3",
-        "semver": "^7.7.4",
-        "tinyglobby": "^0.2.15"
+        "semver": "^7.8.5",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "eleventy": "cmd.cjs"
       },
       "engines": {
-        "node": ">=20.19"
+        "node": ">=22.15"
       },
       "funding": {
         "type": "opencollective",
@@ -225,17 +226,17 @@
       }
     },
     "node_modules/@11ty/eleventy-plugin-bundle": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-bundle/-/eleventy-plugin-bundle-3.0.7.tgz",
-      "integrity": "sha512-QK1tRFBhQdZASnYU8GMzpTdsMMFLVAkuU0gVVILqNyp09xJJZb81kAS3AFrNrwBCsgLxTdWHJ8N64+OTTsoKkA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-bundle/-/eleventy-plugin-bundle-4.0.2.tgz",
+      "integrity": "sha512-eIrfJ3x1B8HtpNKQItCWgzYqgJiPYyAbkxAvhLkabhA4adkAEMvM2m5yM/5Hgj9M1tG7CZ1q9dR9eqw1mLAy1A==",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy-utils": "^2.0.2",
-        "debug": "^4.4.0",
+        "@11ty/eleventy-utils": "^2.0.7",
+        "obug": "^2.1.3",
         "posthtml-match-helper": "^2.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "type": "opencollective",
@@ -404,14 +405,10 @@
       }
     },
     "node_modules/@11ty/nunjucks": {
-      "version": "4.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@11ty/nunjucks/-/nunjucks-4.0.0-alpha.1.tgz",
-      "integrity": "sha512-9n/Qhxk/U8cTgGTv2OgOmeAd4qMJa/46nOpvdjR3d4K342ghli027qkMvtkO69MfCceBfnyZbZrxOyxfZgOkwg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "a-sync-waterfall": "^1.0.1",
-        "asap": "^2.0.6"
-      }
+      "version": "4.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@11ty/nunjucks/-/nunjucks-4.0.0-alpha.3.tgz",
+      "integrity": "sha512-oWDW+MtBq8dKrx/njAjCXxrThS5q0Fvaj632a9RwUqKhddeOAgqKN5odvev/PSpkSTGhrLRkaLkjAVrvqrdKsQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@11ty/parse-date-strings": {
       "version": "2.0.6",
@@ -1419,12 +1416,6 @@
       "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
       "license": "MIT"
     },
-    "node_modules/a-sync-waterfall": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "license": "MIT"
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1475,12 +1466,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
-    },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -1549,15 +1534,15 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brotli-size": {
@@ -2350,9 +2335,9 @@
       }
     },
     "node_modules/github-publish/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -2531,9 +2516,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -2829,9 +2814,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",
@@ -2848,9 +2833,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
-      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.29.0.tgz",
+      "integrity": "sha512-pCVOhs6FLAR8su3ItJ07diN26t6W5dHQRnmTMy8HPyTFuv1+oSCVJIGp5pGjfQyOZfh50KswvKtMTp6p4JEIdw==",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"
@@ -3127,6 +3112,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -3810,9 +3808,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elva",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elva",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "4.0.0-alpha.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@inquirer/prompts": "^8.4.2",
         "@minify-html/node": "^0.18.1",
         "alpinejs": "^3.15.12",
-        "browserslist": "^4.28.4",
+        "browserslist": "^4.28.6",
         "cheerio": "^1.2.0",
         "dot-prop": "^10.1.0",
         "eleventy-plugin-embed-everything": "^1.21.2",
@@ -1492,9 +1492,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1592,10 +1592,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -1612,9 +1612,9 @@
       "license": "MIT"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1940,9 +1940,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.377",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.377.tgz",
-      "integrity": "sha512-cH1jZgJHoezfTnKfKwnScpHywTFVnJUNITDPREFdhNjiuD502+QFpG0Qk7G8jhsV/f+CEAFlIrzP1fT+IMb92g==",
+      "version": "1.5.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
       "license": "ISC"
     },
     "node_modules/eleventy-plugin-embed-bluesky": {
@@ -3089,9 +3089,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@11ty/eleventy": "4.0.0-alpha.10",
         "@11ty/eleventy-fetch": "^5.1.3",
-        "@11ty/eleventy-img": "^6.0.4",
+        "@11ty/eleventy-img": "^7.0.0",
         "@11ty/eleventy-navigation": "^1.0.5",
         "@11ty/eleventy-plugin-rss": "^3.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
@@ -178,38 +178,59 @@
       }
     },
     "node_modules/@11ty/eleventy-img": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-img/-/eleventy-img-6.0.4.tgz",
-      "integrity": "sha512-jSy9BmubVs0mN76dcXWfSYDgRU+1+/rq/SxUR3MgIvTUAJRDop5pFW+Z1f56CDcOlEHaiPqHgnfOlqRmJvXl7g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-img/-/eleventy-img-7.0.0.tgz",
+      "integrity": "sha512-4b8BSTd1XZSax3hFg1Iyv3B3Vc2DmuTenbFr7M0+x4H3fNJDYq3Bctc9rDxiD021hzO7v6MPXXCb5HsQT6//Aw==",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy-fetch": "^5.1.0",
+        "@11ty/eleventy-fetch": "^5.1.3",
         "@11ty/eleventy-utils": "^2.0.7",
         "brotli-size": "^4.0.0",
-        "debug": "^4.4.0",
-        "entities": "^6.0.0",
-        "image-size": "^1.2.1",
-        "p-queue": "^6.6.2",
-        "sharp": "^0.33.5"
+        "entities": "^8.0.0",
+        "obug": "^2.1.4",
+        "p-queue": "^9.3.3",
+        "sharp": "^0.35.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
       }
     },
-    "node_modules/@11ty/eleventy-img/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
+    "node_modules/@11ty/eleventy-img/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20"
       },
       "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@11ty/eleventy-navigation": {
@@ -453,9 +474,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -471,10 +492,19 @@
         "@skypack/package-check": "^0.2.2"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -484,19 +514,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -506,19 +536,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -532,9 +581,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -548,11 +597,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -564,11 +616,52 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -580,11 +673,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -596,11 +692,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -612,11 +711,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -628,11 +730,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -644,33 +749,39 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -678,43 +789,99 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -722,43 +889,49 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -766,38 +939,73 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -807,16 +1015,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -826,7 +1034,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1688,47 +1896,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -2419,21 +2586,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
     "node_modules/import-module-string": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/import-module-string/-/import-module-string-2.0.3.tgz",
@@ -2474,12 +2626,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "license": "MIT"
     },
     "node_modules/is-decimal": {
       "version": "2.0.1",
@@ -3483,15 +3629,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.3"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3593,42 +3730,52 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/signal-exit": {
@@ -3641,15 +3788,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "markdown-it-table-of-contents": "^1.2.0",
         "mime-types": "^3.0.2",
         "playwright": "^1.61.1",
-        "terser": "^5.46.1",
+        "terser": "^5.49.0",
         "yoctocolors": "^2.1.2"
       }
     },
@@ -3725,9 +3725,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "markdown-it-sup": "^2.0.0",
         "markdown-it-table-of-contents": "^1.2.0",
         "mime-types": "^3.0.2",
-        "playwright": "^1.61.0",
+        "playwright": "^1.61.1",
         "terser": "^5.46.1",
         "yoctocolors": "^2.1.2"
       }
@@ -3276,33 +3276,33 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/pony-cause": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "4.0.0-alpha.7",
-        "@11ty/eleventy-fetch": "^5.1.2",
+        "@11ty/eleventy-fetch": "^5.1.3",
         "@11ty/eleventy-img": "^6.0.4",
         "@11ty/eleventy-navigation": "^1.0.5",
         "@11ty/eleventy-plugin-rss": "^3.0.0",
@@ -157,13 +157,13 @@
       }
     },
     "node_modules/@11ty/eleventy-fetch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-5.1.2.tgz",
-      "integrity": "sha512-YxDARdR3S9UT4gOGRWgGNyokYT9jkCAjJge3OVKFdNMv1cyvWg1NHCvj9NVvK9XHenCLFy3cwvM/YYpZZTZopw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-5.1.3.tgz",
+      "integrity": "sha512-4HS6QB/mVWTVlE6kjCKPkjkC1Z0YOqizJaHR05zK+E7a2b4EUC3T+wLktIy7wEl76ZoarkY45EKLmTw1XuR8fQ==",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-utils": "^2.0.7",
-        "@rgrove/parse-xml": "^4.2.0",
+        "@rgrove/parse-xml": "^4.2.1",
         "debug": "^4.4.3",
         "flatted": "^3.4.2",
         "p-queue": "6.6.2"
@@ -1321,9 +1321,9 @@
       }
     },
     "node_modules/@rgrove/parse-xml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-4.2.0.tgz",
-      "integrity": "sha512-UuBOt7BOsKVOkFXRe4Ypd/lADuNIfqJXv8GvHqtXaTYXPPKkj2nS2zPllVsrtRjcomDhIJVBnZwfmlI222WH8g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-4.2.2.tgz",
+      "integrity": "sha512-KJpwSfVwrZ1Ab9KU4oRwG0VefGpveSt/w/j1m6YkJkB5KhdDbN/7BS0ojcLCzrG3/YGFhtfFHKVBkrms6w8Org==",
       "license": "ISC",
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@11ty/eleventy": "4.0.0-alpha.8",
+    "@11ty/eleventy": "4.0.0-alpha.7",
     "@11ty/eleventy-fetch": "^5.1.2",
     "@11ty/eleventy-img": "^6.0.4",
     "@11ty/eleventy-navigation": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@11ty/eleventy": "4.0.0-alpha.7",
+    "@11ty/eleventy": "4.0.0-alpha.8",
     "@11ty/eleventy-fetch": "^5.1.2",
     "@11ty/eleventy-img": "^6.0.4",
     "@11ty/eleventy-navigation": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "markdown-it-sup": "^2.0.0",
     "markdown-it-table-of-contents": "^1.2.0",
     "mime-types": "^3.0.2",
-    "playwright": "^1.61.0",
+    "playwright": "^1.61.1",
     "terser": "^5.46.1",
     "yoctocolors": "^2.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@11ty/eleventy": "4.0.0-alpha.10",
     "@11ty/eleventy-fetch": "^5.1.3",
-    "@11ty/eleventy-img": "^6.0.4",
+    "@11ty/eleventy-img": "^7.0.0",
     "@11ty/eleventy-navigation": "^1.0.5",
     "@11ty/eleventy-plugin-rss": "^3.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@inquirer/prompts": "^8.4.2",
     "@minify-html/node": "^0.18.1",
     "alpinejs": "^3.15.12",
-    "browserslist": "^4.28.4",
+    "browserslist": "^4.28.6",
     "cheerio": "^1.2.0",
     "dot-prop": "^10.1.0",
     "eleventy-plugin-embed-everything": "^1.21.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "@11ty/eleventy": "4.0.0-alpha.7",
-    "@11ty/eleventy-fetch": "^5.1.2",
+    "@11ty/eleventy-fetch": "^5.1.3",
     "@11ty/eleventy-img": "^6.0.4",
     "@11ty/eleventy-navigation": "^1.0.5",
     "@11ty/eleventy-plugin-rss": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "markdown-it-table-of-contents": "^1.2.0",
     "mime-types": "^3.0.2",
     "playwright": "^1.61.1",
-    "terser": "^5.46.1",
+    "terser": "^5.49.0",
     "yoctocolors": "^2.1.2"
   },
   "allowScripts": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@11ty/eleventy": "4.0.0-alpha.7",
+    "@11ty/eleventy": "4.0.0-alpha.10",
     "@11ty/eleventy-fetch": "^5.1.3",
     "@11ty/eleventy-img": "^6.0.4",
     "@11ty/eleventy-navigation": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elva",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "A multilingual, clean, green, 11ty starter theme",
   "main": "index.js",
   "type": "module",

--- a/themes/default/_includes/navigation.njk
+++ b/themes/default/_includes/navigation.njk
@@ -1,5 +1,6 @@
 <nav class="navigation">
-    <a class="site-logo" href="{{ "/" | locale_url }}" {% if page.url === '/' %}aria-current="page"{% endif %} aria-label="{{ 'header.home' | translate }}">
+    {% set home = '/' | locale_url | defaultlocaleurl %}
+    <a class="site-logo" href="{{ home }}" {% if page.url === home %}aria-current="page"{% endif %} aria-label="{{ 'header.home' | translate }}">
         <svg fill="none" height="242" viewBox="0 0 541 242" width="541" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-labelledby="logo-title" role="img">
             <title id="logo-title">{{ 'meta.title' | translate }}</title>
             <clipPath id="a"><path d="m0 0h541v242h-541z"/></clipPath>

--- a/themes/default/js/search.js
+++ b/themes/default/js/search.js
@@ -7,11 +7,19 @@ document.addEventListener('alpine:init', () => {
         loaded: false,
         apiURL: '{{ "/api/search.json" | locale_url }}',
         async init() {
+            const params = new URLSearchParams(window.location.search);
+            const q = params.get('q');
+            if (q) {
+                this.query = q;
+            }
             try {
                 const response = await fetch(this.apiURL);
                 if (response.ok) {
                     const data = await response.json();
                     this.allResults = data.data || [];
+                    if (q) {
+                        this.filter();
+                    }
                 }
             } catch (e) {
                 console.warn('Search API not found:', e);


### PR DESCRIPTION
* Update taxonomyDb in Front Matter CMS (with new tags)
* Pass common search `?q=` parameter into search component
* Move search form higher on 404 pages
* ~~Bump 11ty to 4.0.0-alpha.8~~ (seems to cause an issue with CSS refreshes / builds)
* Bump 11ty to 4.0.0-alpha.10
* Fix bug where current navigation property was not set on the logo of secondary languages
* Bump 11ty fetch to 5.1.3
* Bump browserlist to 4.28.6
* Bump playwright to 1.61.1
* Bump terser to 5.49.0
* Bump 11ty image to 7.0.0